### PR TITLE
wiki working

### DIFF
--- a/djWebsite/settings.py
+++ b/djWebsite/settings.py
@@ -40,6 +40,17 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sites', # django 1.6.2+
+    'django.contrib.humanize',
+    'django_nyt',
+    'mptt',
+    'sekizai',
+    'sorl.thumbnail',
+    'wiki',
+    'wiki.plugins.attachments',
+    'wiki.plugins.notifications',
+    'wiki.plugins.images',
+    'wiki.plugins.macros',
 ]
 
 MIDDLEWARE_CLASSES = [
@@ -62,10 +73,15 @@ TEMPLATES = [
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.request',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
+                "sekizai.context_processors.sekizai",
             ],
         },
     },
@@ -126,3 +142,7 @@ STATIC_URL = '/static/'
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "static/")
 ]
+
+
+#added for wiki
+SITE_ID = 1

--- a/djWebsite/urls.py
+++ b/djWebsite/urls.py
@@ -16,9 +16,14 @@ Including another URLconf
 from django.conf.urls import url, include
 from django.contrib import admin
 
+from wiki.urls import get_pattern as get_wiki_pattern
+from django_nyt.urls import get_pattern as get_nyt_patern
+
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^$', include('homepage.urls')),
     url(r'^Calendar/', include('Calendar.urls')),
     url(r'^news/', include('news.urls', namespace='news')),
+    url(r'notifications/', get_nyt_patern()),
+    url(r'^wiki/', get_wiki_pattern()),
 ]

--- a/navbar/templates/navbar/navbar.html
+++ b/navbar/templates/navbar/navbar.html
@@ -18,7 +18,7 @@
                     <li><a href="#"> News </a></li>
                     <li><a href="http://csci.club/Calendar"> Calendar </a></li>
                     <li><a href="https://github.com/CSCIClub"> Projects </a></li>
-                    <li><a href="#"> Wiki </a></li>
+                    <li><a href="wiki/"> Wiki </a></li>
                     <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"> Events <span class="caret"></span></a>
                         <ul class="dropdown-menu" role="menu">


### PR DESCRIPTION
Let's merge in the wiki code. The wiki will not work for users that have not installed the wiki package via pip3. 

The user must type "pip3 install wiki" before running the test server locally. 
